### PR TITLE
Don't export per second rates.

### DIFF
--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -106,21 +106,9 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
 
    // Send counters
    for (key in counters) {
-      value = counters[key];
-      // Fetch the pre-caculated rate
-      var valuePerSecond = counter_rates[key];
-
-      payload.push({
-         metric: get_prefix(key) + ".per_second",
-         points: [[ts, valuePerSecond]],
-         type: 'gauge',
-         host: host,
-         tags: datadogTags
-      });
-
       payload.push({
          metric: get_prefix(key),
-         points: [[ts, value]],
+         points: [[ts, counters[key]]],
          type: 'counter',
          host: host,
          tags: datadogTags


### PR DESCRIPTION
# What's this PR do?

Removes the `.per_second` metric from the StatsD backend.
# Motivation

Reduce metrics and not export a rate because you can do that with the `per_second()` function in Datadog.
# How To Deploy

Merge and deploy to QA with `henson --qa statsd`. Restart statsd on qa-stats1.nw with `svc -t /etc/service/statsd`.
# How to Measure Success

No more `.per_second` metrics.
# How to Rollback

Revert and deploy.

r? @rhwlo
